### PR TITLE
特殊な問題文が表示できない不具合を修正

### DIFF
--- a/src/renderer/logic/QuizDataUtil.js
+++ b/src/renderer/logic/QuizDataUtil.js
@@ -24,11 +24,20 @@ export default class QuizDataUtil {
   static createQuizData (qIdCell) {
     return {
       qId: qIdCell.value(),
-      qText: qIdCell.relativeCell(0, 1).value(),
-      qAnswer: qIdCell.relativeCell(0, 2).value(),
-      qAnotherAnswer: (qIdCell.relativeCell(0, 3).value() || qIdCell.relativeCell(0, 3).value() === 0)
+      qText: this.formatImportedText(qIdCell.relativeCell(0, 1).value()),
+      qAnswer: this.formatImportedText(qIdCell.relativeCell(0, 2).value()),
+      qAnotherAnswer: this.formatImportedText((qIdCell.relativeCell(0, 3).value() || qIdCell.relativeCell(0, 3).value() === 0)
         ? qIdCell.relativeCell(0, 3).value()
-        : ''
+        : '')
+    }
+  }
+
+  static formatImportedText (target) {
+    if (Array.isArray(target)) {
+      // セル内の文字の一部に書式が設定されているような場合、こちらのフローに入る
+      return target.filter(prop => prop.name === 'r').map(r => r.children.filter(prop => prop.name === 't')[0].children[0]).join('')
+    } else {
+      return target
     }
   }
 


### PR DESCRIPTION
close #1 

上付き文字などセル文字列の一部に書式設定されていると、xlsx-populateで文字列を取得するときにStringにならない。
そこで、https://qiita.com/8amjp/items/9c57b9b07c0a7bf2fcba の解決策を問題文、解答、別解に適用した。